### PR TITLE
update clap and kiss3d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ exclude = [".gitignore", "tests/**", "target/**"]
 
 [dependencies]
 anyhow = { version = "1.0.31" }
-kiss3d = { version = "0.27.0" }
-nalgebra = { version = "0.23" }
-clap = { features = ["suggestions", "color"], version = "3.0.0-beta.1" }
+kiss3d = { version = "0.35" }
+nalgebra = { version = "0.30" }
+clap = { features = ["suggestions", "color", "derive"], version = "4.0.18" }
 
 
 [lib]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ mod renderer;
 mod viewer;
 
 use anyhow::Result;
-use clap::{crate_authors, crate_version, Clap};
+use clap::Parser;
 use kiss3d::resource::{AllocationType, BufferType, GPUVec};
 use kiss3d::window::Window;
 
@@ -12,8 +12,8 @@ use renderer::PointCloudRenderer;
 use viewer::AppState;
 use viewercloud::{PointCloud, PointCloudGPU};
 /// Display KITTI 3D Pointcloud with annotations and your model inferences
-#[derive(Clap)]
-#[clap(version = crate_version!(), author = crate_authors!())]
+#[derive(Parser, Debug)]
+#[command(author, version)]
 struct Opts {
     ///Path to the kitti Pointcloud .bin or .txt file
     pointcloud_file: String,


### PR DESCRIPTION
Slight changes to update the Clap syntax to the new version.

I needed to update kiss3d, because there was a bug with the `winit` crate causing an uninitialized X11 pointer.